### PR TITLE
Add test for std::optional, bump tests to C++17

### DIFF
--- a/tests/genpybind_waf.py
+++ b/tests/genpybind_waf.py
@@ -190,7 +190,7 @@ class genpybind(Task.Task): # pylint: disable=invalid-name
         args.append("-xc++" if is_cxx else "-xc")
         args.extend(
             flag.replace("-std=gnu", "-std=c")
-            .replace("-std=c++11", "-std=c++14") # FIXME: move to genpybind-parse tool
+            .replace("-std=c++11", "-std=c++17") # FIXME: move to genpybind-parse tool
             for flag in self.env["CXXFLAGS" if is_cxx else "CFLAGS"])
         args.extend("-I{}".format(n.abspath()) for n in self._include_paths())
         args.extend("-D{}".format(p) for p in self.env.DEFINES)

--- a/tests/optional_parameters.cpp
+++ b/tests/optional_parameters.cpp
@@ -1,0 +1,3 @@
+#include "optional_parameters.h"
+
+std::optional<int> GENPYBIND(visible) foo(std::optional<int> o) { return o; }

--- a/tests/optional_parameters.h
+++ b/tests/optional_parameters.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#if !__has_include("optional")
+#include <experimental/optional>
+namespace std {
+template<typename T>
+using optional = std::experimental::optional<T>;
+using nullopt_t = std::experimental::nullopt_t;
+using std::experimental::nullopt;
+}
+#else
+#include <optional>
+#endif
+
+#include "genpybind.h"
+
+std::optional<int> GENPYBIND(visible) foo(std::optional<int> o = std::nullopt);

--- a/tests/optional_parameters_test.py
+++ b/tests/optional_parameters_test.py
@@ -1,0 +1,9 @@
+import pytest
+import pyoptional_parameters as m
+
+def test_optional_parameters():
+    assert hasattr(m, 'foo')
+    assert m.foo(0) == 0
+    assert m.foo(10) == 10
+    assert m.foo(None) is None
+    assert m.foo() is None

--- a/tests/wscript
+++ b/tests/wscript
@@ -37,7 +37,7 @@ def configure(cfg):
         uselib_store="PYBIND11",
         mandatory=True,
         header_name="pybind11/pybind11.h",
-        cxxflags="-std=c++11",
+        cxxflags="-std=c++17",
         includes=cfg.options.pybind11_includes,
     )
 
@@ -97,7 +97,7 @@ def build(bld):
             source=node,
             features="cxx cxxshlib",
             export_includes=".",
-            cxxflags="-std=c++11",
+            cxxflags="-std=c++17",
             install_path=None,
         )
 


### PR DESCRIPTION
Should we add a configuration switch for C++17 things like `std::optional`?