### PR TITLE
Fix wrapping for pybind11::{,kw}args arguments

### DIFF
--- a/genpybind/decls/callables.py
+++ b/genpybind/decls/callables.py
@@ -134,8 +134,15 @@ class Callable(Declaration):
     def arguments(self):
         # type: () -> List[Text]
         args = []
+        is_after_args_or_kwargs = False
         for idx, child in enumerate(
                 cutils.children_by_kind(self.cursor, CursorKind.PARM_DECL)):
+            # according to pybind11 docs do not use pybind11::arg for pybind11::{args,kwargs} types
+            if child.type.fully_qualified_name in ['::pybind11::args', '::pybind11::kwargs']:
+                is_after_args_or_kwargs = True
+                continue
+            if is_after_args_or_kwargs:
+                 raise RuntimeError("py::args / py::kwargs cannot be followed by other arguments")
             default_value = ""
             expr = next(cutils.children_by_kind(child, cutils.EXPRESSION_KINDS), None)
             if expr:

--- a/tests/argsandkwargs.cpp
+++ b/tests/argsandkwargs.cpp
@@ -1,0 +1,34 @@
+#include <pybind11/pybind11.h>
+
+#include "argsandkwargs.h"
+
+int test_args(pybind11::args args) {
+	return pybind11::len(args);
+}
+
+int test_kwargs(pybind11::kwargs kwargs) {
+	size_t ret = 0;
+	for (auto const& elem: kwargs)
+		ret += pybind11::len(elem.second);
+	return ret;
+}
+
+int test(pybind11::args args) {
+	return test_args(args);
+}
+
+int test(pybind11::kwargs kwargs) {
+	return test_kwargs(kwargs);
+}
+
+int test(int i, float f, pybind11::args args) {
+	return test_args(args);
+}
+
+int test(int i, float f, pybind11::kwargs kwargs) {
+	return test_kwargs(kwargs);
+}
+
+int test(int i, float f, pybind11::args args, pybind11::kwargs kwargs) {
+	return test_args(args) + test_kwargs(kwargs);
+}

--- a/tests/argsandkwargs.h
+++ b/tests/argsandkwargs.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "genpybind.h"
+
+namespace pybind11 {
+class args;
+class kwargs;
+}
+
+#define SYMBOL_VISIBLE __attribute__((visibility("default")))
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test_args(pybind11::args args);
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test_kwargs(pybind11::kwargs kwargs);
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test(pybind11::args args);
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test(pybind11::kwargs kwargs);
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test(int i, float f, pybind11::args args);
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test(int i, float f, pybind11::kwargs kwargs);
+
+GENPYBIND(visible) SYMBOL_VISIBLE
+int test(int i, float f, pybind11::args args, pybind11::kwargs kwargs);

--- a/tests/argsandkwargs_test.py
+++ b/tests/argsandkwargs_test.py
@@ -1,0 +1,17 @@
+import pyargsandkwargs as m
+
+def test_args():
+    assert m.test_args() == 0
+    assert m.test_args(0,1,2,3) == 4
+
+def test_kwargs():
+    assert m.test_kwargs() == 0
+    assert m.test_kwargs(abc=[0,1,2,3]) == 4
+
+def test_overloads():
+    assert m.test() == 0
+    assert m.test(abc=[0,1,2,3]) == 4
+    assert m.test(1, 0.1) == 2
+    assert m.test(1, 0.1, 0, 1, 2, 3) == 6
+    assert m.test(1, 0.1, abc=[0,1,2,3]) == 4
+    assert m.test(1, 0.1, 0, 1, 2, abc=[0,1,2,3]) == 7

--- a/tests/wscript
+++ b/tests/wscript
@@ -95,7 +95,7 @@ def build(bld):
         bld(
             target=target,
             source=node,
-            features="cxx cxxshlib",
+            features="cxx cxxshlib pyembed",
             export_includes=".",
             cxxflags="-std=c++11",
             install_path=None,
@@ -108,6 +108,7 @@ def build(bld):
             genpybind_tags=["all_tests", target],
             use=[target, "PYBIND11"],
             install_path=None,
+            linkflags='-Wl,-z,defs',
             pytest_path=[bld.path.get_bld()],
         )
 


### PR DESCRIPTION
@kljohann That's just a draft → can you suggest something regarding how to obtain the fully qualified name of the argument in a nicer way (the cutils getter asserts on a list of KINDs where the PARAM type is not included). Regarding test build we could also add some "needs-pyembed" section (maybe extra folder?).