### PR TITLE
Add failing test default argument templated function

### DIFF
--- a/tests/default_arguments.cpp
+++ b/tests/default_arguments.cpp
@@ -1,3 +1,8 @@
 #include "default_arguments.h"
 
 constexpr int example::Y::N;
+
+template <typename T>
+int function_templated(T o) { return o; }
+
+template GENPYBIND(visible) int function_templated<int>(int o = 42);

--- a/tests/default_arguments.h
+++ b/tests/default_arguments.h
@@ -19,6 +19,11 @@ void GENPYBIND(visible) function_class_in_namespace(Y y = Y()) {}
 void GENPYBIND(visible)
     function_class_outside_namespace(example::Y y = example::Y()) {}
 
+template <typename T>
+int GENPYBIND(visible) function_templated(T o = T(42));
+
+extern template int GENPYBIND(visible) function_templated<int>(int o = 42);
+
 // TODO: genpybind uses `example::Y::N` as default argument?
 /*
 void GENPYBIND(visible) function_template_outside_namespace(

--- a/tests/default_arguments_test.py
+++ b/tests/default_arguments_test.py
@@ -11,6 +11,7 @@ import pydefault_arguments as m
     "class_outside_namespace",
     "braced_outside_namespace",
     "template_outside_namespace",
+    "templated",
 ])
 def test_default_arguments(variant):
     # TODO: braced initialization not supported in default argument


### PR DESCRIPTION
The bindings loose the default argument, if the function is a template specialisation.
This test breaks the test routine and is only meant to document the problem at this point.