### PR TITLE
Fix missing namespace in typedef

### DIFF
--- a/genpybind/decls/callables.py
+++ b/genpybind/decls/callables.py
@@ -102,7 +102,7 @@ class Callable(Declaration):
 
         return "typedef {ret} ({namespace}*{name}) ({arguments}){qualifiers};".format(
             name=name,
-            ret=self.cursor.type.get_result().fully_qualified_name,
+            ret=self.cursor.type.get_result().get_canonical().fully_qualified_name,
             arguments=join_arguments(self.argument_types()),
             namespace=namespace,
             qualifiers=" " + (" ".join(qualifiers)) if qualifiers else "",

--- a/tests/template_class.cpp
+++ b/tests/template_class.cpp
@@ -1,0 +1,1 @@
+#include "template_class.h"

--- a/tests/template_class.h
+++ b/tests/template_class.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <array>
+#include "genpybind.h"
+
+namespace somewhere {
+
+	template<typename T>
+struct TBase {
+	constexpr static unsigned num_words = 1;
+
+	std::array<int, num_words> do_something() { return {}; }
+};
+
+} // namespace somewhere
+
+template class somewhere::TBase<int>;
+
+GENPYBIND(opaque)
+typedef somewhere::TBase<int> TBase_int;

--- a/tests/template_class_test.py
+++ b/tests/template_class_test.py
@@ -1,0 +1,6 @@
+import pytest
+import pytemplate_class as m
+
+def test_templated_typedef():
+    assert getattr(m.TBase_int, 'do_something', False)
+


### PR DESCRIPTION
Hey @kljohann,

we encountered a problem when wrapping code which generates typedefs (i.e. a function pointer) to member variables which refer to other namespaced class members.

Problem:
Code is generated which looks like
`typedef ::std::array<int, num_words> (::somewhere::TBase<int>::*genpybind_do_something_type) (); `,
where `num_words` should be `::somewhere::TBase<int>::num_words`.

Using the `get_canonical()` call, clang resolves `num_words` into `1`, thus:
`typedef ::std::array<int, 1> (::somewhere::TBase<int>::*genpybind_do_something_type) (); `.

```python
    def get_canonical(self):
        """
        Return the canonical type for a Type.
        Clang's type system explicitly models typedefs and all the
        ways a specific type can be represented.  The canonical type
        is the underlying type with all the "sugar" removed.  For
        example, if 'T' is a typedef for 'int', the canonical type for
        'T' would be 'int'.
        """
```