### PR TITLE
Fix pybind11 check

### DIFF
--- a/tests/wscript
+++ b/tests/wscript
@@ -33,7 +33,7 @@ def configure(cfg):
 
     cfg.check(
         compiler="cxx",
-        features="cxx pyext",
+        features="cxx cxxshlib pyext",
         uselib_store="PYBIND11",
         mandatory=True,
         header_name="pybind11/pybind11.h",


### PR DESCRIPTION
`link_task` isn't defined if we only specify an "objects"-like build context.